### PR TITLE
Small stop fixes

### DIFF
--- a/src/robothub_depthai/manager.py
+++ b/src/robothub_depthai/manager.py
@@ -44,10 +44,8 @@ class HubCameraManager:
         if not self.hub_cameras:
             # Endless loop to prevent app from exiting if no devices are found
             while True:
-                try:
-                    time.sleep(1)
-                except KeyboardInterrupt:
-                    break
+                self.app.wait(1)
+
 
         print('Starting cameras...')
         for camera in self.hub_cameras:


### PR DESCRIPTION
- Stop app should be used rather than KeyboardInterrupt signal (which is already collected elsewhere)
- self.app.wait(1) stops waiting if app has been stopped (to prevent a one second long shutdown of app)